### PR TITLE
feat: Improve popup layout with optimized width and content spacing

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -4,6 +4,12 @@
     box-sizing: border-box;
 }
 
+html {
+    width: 500px;
+    min-width: 500px;
+    max-width: 500px;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
     font-size: 14px;
@@ -12,13 +18,23 @@ body {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     min-height: 600px;
     width: 500px;
+    min-width: 500px;
+    max-width: 500px;
 }
 
 .container {
     background: #ffffff;
     min-height: 600px;
+    width: 500px;
+    min-width: 500px;
+    max-width: 500px;
     display: flex;
     flex-direction: column;
+}
+
+/* Main content area with left/right spacing */
+main {
+    padding: 20px;
 }
 
 /* Header */

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=500, initial-scale=1.0">
     <title>Meta Tags Checker</title>
     <link rel="stylesheet" href="popup.css">
 </head>


### PR DESCRIPTION
- Set popup width to 500px for better usability
- Add 20px left/right padding to main content area
- Keep header at full width for visual consistency
- Update viewport meta tag for proper width enforcement
- Add explicit width constraints to HTML, body, and container elements